### PR TITLE
Add a namespace for Gradle 8 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,6 +23,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.flux.flutter_boot_receiver'
     compileSdkVersion 31
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
This change works with Gradle 8, so the `flutter_boot_receiver` package is compatible with the Android-specific tooling that Flutter configures in new projects. It also works with Gradle 7, supporting older Flutter apps that have not upgraded their `android/` directory.

This PR resolves issue #7.