### PR TITLE
feat: migrate to Flutter V2 embedding and modern Android APIs

### DIFF
--- a/.idea/libraries/Flutter_Plugins.xml
+++ b/.idea/libraries/Flutter_Plugins.xml
@@ -1,8 +1,6 @@
 <component name="libraryTable">
   <library name="Flutter Plugins" type="FlutterPluginsLibraryType">
-    <CLASSES>
-      <root url="file://$PROJECT_DIR$" />
-    </CLASSES>
+    <CLASSES />
     <JAVADOC />
     <SOURCES />
   </library>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,6 +2,5 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/flux/android" vcs="Git" />
   </component>
 </project>

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip

--- a/android/src/main/java/com/flux/flutter_boot_receiver/BootBroadcastReceiver.java
+++ b/android/src/main/java/com/flux/flutter_boot_receiver/BootBroadcastReceiver.java
@@ -3,23 +3,29 @@ package com.flux.flutter_boot_receiver;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.content.SharedPreferences;
-import android.os.Build;
 import android.util.Log;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.util.Calendar;
 
 public class BootBroadcastReceiver extends BroadcastReceiver {
+  private static final String TAG = "BootBroadcastReceiver";
+
   @Override
   public void onReceive(Context context, Intent intent) {
-    if (intent.getAction().equals("android.intent.action.BOOT_COMPLETED") ||
-        intent.getAction().equals(
-            "android.intent.action.LOCKED_BOOT_COMPLETED") ||
-        intent.getAction().equals("android.intent.action.QUICKBOOT_POWERON") ||
-        intent.getAction().equals("com.htc.intent.action.QUICKBOOT_POWERON")) {
-      Log.i("BootBroadcastReceiver", "Boot Completed");
-      BootHandlerService.enqueueOnReceiveProcessing(context, intent);
+    String action = intent.getAction();
+    Log.i(TAG, "Received broadcast: " + action);
+
+    if (isBootCompletedAction(action)) {
+      Log.i(TAG, "Boot completed received, processing...");
+      // Use the new static method to process the intent
+      BootHandlerService.processIntent(context, intent);
+    } else {
+      Log.w(TAG, "Unhandled broadcast action: " + action);
     }
+  }
+
+  private boolean isBootCompletedAction(String action) {
+    return Intent.ACTION_BOOT_COMPLETED.equals(action) ||
+            Intent.ACTION_LOCKED_BOOT_COMPLETED.equals(action) ||
+            "android.intent.action.QUICKBOOT_POWERON".equals(action) ||
+            "com.htc.intent.action.QUICKBOOT_POWERON".equals(action);
   }
 }

--- a/android/src/main/java/com/flux/flutter_boot_receiver/BootHandlerService.java
+++ b/android/src/main/java/com/flux/flutter_boot_receiver/BootHandlerService.java
@@ -1,67 +1,75 @@
 package com.flux.flutter_boot_receiver;
 
-// Copyright 2017 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
-import android.content.SharedPreferences;
-import android.os.Build;
 import android.os.Handler;
+import android.os.Looper;
 import android.util.Log;
-import androidx.annotation.NonNull;
-import androidx.core.app.JobIntentService;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CountDownLatch;
-import org.json.JSONException;
-import org.json.JSONObject;
 
-public class BootHandlerService extends JobIntentService {
+public class BootHandlerService {
   private static final String TAG = "BootHandlerService";
   protected static final String SHARED_PREFERENCES_KEY = "com.flux.flutter_boot_receiver";
-  private static final int JOB_ID = 1984; // Random job ID.
 
   private static final List<Intent> mQueue = Collections.synchronizedList(new LinkedList<>());
-
   private static FlutterBackgroundExecutor mFlutterBackgroundExecutor;
+  private static volatile boolean mIsInitialized = false;
 
-  private static Context mContext;
-
-  public static void enqueueOnReceiveProcessing(Context context, Intent intent) {
-    enqueueWork(context, BootHandlerService.class, JOB_ID, intent);
-  }
-
+  /**
+   * Called when the Dart isolate is ready to handle callbacks.
+   */
   static void onInitialized() {
     Log.i(TAG, "BootHandlerService started!");
+    mIsInitialized = true;
+
     synchronized (mQueue) {
-      // Handle all the events received before the Dart isolate was
-      // initialized, then clear the mQueue.
       for (Intent intent : mQueue) {
-        mFlutterBackgroundExecutor.executeDartCallbackInBackgroundIsolate(mContext, intent, null);
+        executeDartCallback(intent, null);
       }
       mQueue.clear();
     }
   }
 
   /**
+   * Processes an intent with the background Dart isolate.
+   */
+  public static void processIntent(Context context, Intent intent) {
+    if (mFlutterBackgroundExecutor == null) {
+      mFlutterBackgroundExecutor = new FlutterBackgroundExecutor();
+      mFlutterBackgroundExecutor.startBackgroundIsolate(context);
+    }
+
+    synchronized (mQueue) {
+      if (!mIsInitialized || !mFlutterBackgroundExecutor.isRunning()) {
+        Log.i(TAG, "BootHandlerService has not yet started. Queuing intent.");
+        mQueue.add(intent);
+        return;
+      }
+    }
+
+    Log.i(TAG, "Handling Boot Complete...");
+    executeDartCallback(intent, null);
+  }
+
+  private static void executeDartCallback(Intent intent, CountDownLatch latch) {
+    if (mFlutterBackgroundExecutor == null) {
+      Log.e(TAG, "FlutterBackgroundExecutor not initialized");
+      if (latch != null) {
+        latch.countDown();
+      }
+      return;
+    }
+
+    new Handler(Looper.getMainLooper()).post(() -> {
+      mFlutterBackgroundExecutor.executeDartCallbackInBackgroundIsolate(intent, latch);
+    });
+  }
+
+  /**
    * Starts the background isolate for the {@link BootHandlerService}.
-   *
-   * <p>
-   * Preconditions:
-   *
-   * <ul>
-   * <li>The given {@code callbackHandle} must correspond to a registered Dart
-   * callback. If the
-   * handle does not resolve to a Dart callback then this method does nothing.
-   * <li>A static {@link #pluginRegistrantCallback} must exist, otherwise a {@link
-   * PluginRegistrantException} will be thrown.
-   * </ul>
    */
   public static void startBackgroundIsolate(Context context, long callbackDispatcherHandle) {
     if (mFlutterBackgroundExecutor != null) {
@@ -74,56 +82,27 @@ public class BootHandlerService extends JobIntentService {
 
   /**
    * Sets the Dart callback handle for the Dart method that is responsible for
-   * initializing the
-   * background Dart isolate, preparing it to receive Dart callback tasks
-   * requests.
+   * initializing the background Dart isolate.
    */
   public static void setCallbackHandles(Context context, long callbackDispatcherHandle, long callbackHandle) {
     FlutterBackgroundExecutor.setCallbackHandles(context, callbackDispatcherHandle, callbackHandle);
   }
 
-  @Override
-  public void onCreate() {
-    super.onCreate();
-    if (mFlutterBackgroundExecutor == null) {
-      mFlutterBackgroundExecutor = new FlutterBackgroundExecutor();
-    }
-    mContext = getApplicationContext();
-    mFlutterBackgroundExecutor.startBackgroundIsolate(mContext);
+  /**
+   * Check if the service is ready to handle callbacks.
+   */
+  public static boolean isInitialized() {
+    return mIsInitialized && mFlutterBackgroundExecutor != null && mFlutterBackgroundExecutor.isRunning();
   }
 
   /**
-   * Executes a Dart callback, as specified within the incoming {@code intent}.
-   *
-   * <p>
-   * Invoked by our {@link JobIntentService} superclass after a call to {@link
-   * JobIntentService#enmQueueWork(Context, Class, int, Intent);}.
+   * Clean up resources when no longer needed.
    */
-  @Override
-  protected void onHandleWork(@NonNull final Intent intent) {
-    // If we're in the middle of processing queued events, add the incoming
-    // intent to the queue and return.
+  public static void shutdown() {
     synchronized (mQueue) {
-      if (!mFlutterBackgroundExecutor.isRunning()) {
-        Log.i(TAG, "BootHandlerService has not yet started.");
-        mQueue.add(intent);
-        return;
-      }
+      mQueue.clear();
     }
-
-    Log.i(TAG, "Handling Boot Complete...");
-
-    // There were no pre-existing callback requests. Execute the callback
-    // specified by the incoming intent.
-    final CountDownLatch latch = new CountDownLatch(1);
-    new Handler(getMainLooper())
-        .post(
-            () -> mFlutterBackgroundExecutor.executeDartCallbackInBackgroundIsolate(mContext, intent, latch));
-
-    try {
-      latch.await();
-    } catch (InterruptedException ex) {
-      Log.i(TAG, "Exception waiting to execute Dart callback", ex);
-    }
+    mIsInitialized = false;
+    mFlutterBackgroundExecutor = null;
   }
 }

--- a/android/src/main/java/com/flux/flutter_boot_receiver/FlutterBackgroundExecutor.java
+++ b/android/src/main/java/com/flux/flutter_boot_receiver/FlutterBackgroundExecutor.java
@@ -4,77 +4,46 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.AssetManager;
-import android.text.TextUtils;
 import android.util.Log;
-import android.content.Context;
 import io.flutter.FlutterInjector;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.embedding.engine.dart.DartExecutor.DartCallback;
-import io.flutter.embedding.engine.plugins.shim.ShimPluginRegistry;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.JSONMethodCodec;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry.PluginRegistrantCallback;
 import io.flutter.view.FlutterCallbackInformation;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.json.JSONException;
-import org.json.JSONObject;
-
-// import getApplicationContext;
 
 /**
  * An background execution abstraction which handles initializing a background
- * isolate running a
- * callback dispatcher, used to invoke Dart callbacks while backgrounded.
+ * isolate running a callback dispatcher, used to invoke Dart callbacks while backgrounded.
  */
 public class FlutterBackgroundExecutor implements MethodCallHandler {
     private static final String TAG = "FlutterBackgroundExecutor";
     public static final String CALLBACK_DISPATCHER_HANDLE_KEY = "callback_dispatcher_handle";
     public static final String CALLBACK_HANDLE_KEY = "callback_handle";
-    private static PluginRegistrantCallback pluginRegistrantCallback;
 
-    /**
-     * The {@link MethodChannel} that connects the Android side of this plugin with
-     * the background
-     * Dart isolate that was created by this plugin.
-     */
     private MethodChannel backgroundChannel;
-
     private FlutterEngine backgroundFlutterEngine;
-
     private final AtomicBoolean isCallbackDispatcherReady = new AtomicBoolean(false);
-
-    /**
-     * Sets the {@code PluginRegistrantCallback} used to register plugins with the
-     * newly spawned
-     * isolate.
-     *
-     * <p>
-     * Note: this is only necessary for applications using the V1 engine embedding
-     * API as plugins are automatically registered via reflection in the V2 engine
-     * embedding API.
-     * If not set, dart callbacks will not be able to utilize functionality from
-     * other plugins.
-     */
-    public static void setPluginRegistrant(PluginRegistrantCallback callback) {
-        pluginRegistrantCallback = callback;
-    }
+    private Context storedContext;
 
     /**
      * Sets the Dart callback handle for the Dart method that is responsible for
-     * initializing the
-     * background Dart isolate, preparing it to receive Dart callback tasks
+     * initializing the background Dart isolate, preparing it to receive Dart callback tasks
      * requests.
      */
     public static void setCallbackHandles(Context context, long callbackDispatcherHandle, long callbackHandle) {
         SharedPreferences preferences = context.getSharedPreferences(BootHandlerService.SHARED_PREFERENCES_KEY, 0);
-        preferences.edit().putLong(CALLBACK_DISPATCHER_HANDLE_KEY, callbackDispatcherHandle).apply();
-        preferences.edit().putLong(CALLBACK_HANDLE_KEY, callbackHandle).apply();
+        SharedPreferences.Editor editor = preferences.edit();
+        editor.putLong(CALLBACK_DISPATCHER_HANDLE_KEY, callbackDispatcherHandle);
+        editor.putLong(CALLBACK_HANDLE_KEY, callbackHandle);
+        editor.apply();
     }
 
     /**
@@ -93,56 +62,34 @@ public class FlutterBackgroundExecutor implements MethodCallHandler {
     @Override
     public void onMethodCall(MethodCall call, Result result) {
         String method = call.method;
-        Object arguments = call.arguments;
         try {
             if (method.equals("BootHandlerService.initialized")) {
-                // This message is sent by the background method channel as soon as the
-                // background isolate
-                // is running. From this point forward, the Android side of this plugin can send
-                // callback handles through the background method channel, and the Dart side
-                // will execute
-                // the Dart methods corresponding to those callback handles.
                 onInitialized();
                 result.success(true);
             } else {
                 result.notImplemented();
             }
-        } catch (PluginRegistrantException error) {
+        } catch (Exception error) {
             result.error("error", "FlutterBootReceiver error: " + error.getMessage(), null);
         }
     }
 
     /**
      * Starts running a background Dart isolate within a new {@link FlutterEngine}
-     * using a previously
-     * used entrypoint.
-     *
-     * <p>
-     * The isolate is configured as follows:
-     *
-     * <ul>
-     * <li>Bundle Path: {@code FlutterMain.findAppBundlePath(context)}.
-     * <li>Entrypoint: The Dart method used the last time this plugin was
-     * initialized in the
-     * foreground.
-     * <li>Run args: none.
-     * </ul>
-     *
-     * <p>
-     * Preconditions:
-     *
-     * <ul>
-     * <li>The given callback must correspond to a registered Dart callback. If the
-     * handle does not
-     * resolve to a Dart callback then this method does nothing.
-     * <li>A static {@link #pluginRegistrantCallback} must exist, otherwise a {@link
-     * PluginRegistrantException} will be thrown.
-     * </ul>
+     * using a previously used entrypoint.
      */
     public void startBackgroundIsolate(Context context) {
+        if (backgroundFlutterEngine != null) {
+            Log.e(TAG, "Background isolate already started");
+            return;
+        }
+
+        Log.i(TAG, "Starting BootHandlerService...");
         if (!isRunning()) {
-            SharedPreferences preferences = context.getSharedPreferences(BootHandlerService.SHARED_PREFERENCES_KEY,
-                    0);
+            this.storedContext = context;
+            backgroundFlutterEngine = new FlutterEngine(context);
+
+            SharedPreferences preferences = context.getSharedPreferences(BootHandlerService.SHARED_PREFERENCES_KEY, 0);
             long callbackDispatcherHandle = preferences.getLong(CALLBACK_DISPATCHER_HANDLE_KEY, 0);
             startBackgroundIsolate(context, callbackDispatcherHandle);
         }
@@ -150,26 +97,6 @@ public class FlutterBackgroundExecutor implements MethodCallHandler {
 
     /**
      * Starts running a background Dart isolate within a new {@link FlutterEngine}.
-     *
-     * <p>
-     * The isolate is configured as follows:
-     *
-     * <ul>
-     * <li>Bundle Path: {@code FlutterMain.findAppBundlePath(context)}.
-     * <li>Entrypoint: The Dart method represented by {@code callbackHandle}.
-     * <li>Run args: none.
-     * </ul>
-     *
-     * <p>
-     * Preconditions:
-     *
-     * <ul>
-     * <li>The given {@code callbackHandle} must correspond to a registered Dart
-     * callback. If the
-     * handle does not resolve to a Dart callback then this method does nothing.
-     * <li>A static {@link #pluginRegistrantCallback} must exist, otherwise a {@link
-     * PluginRegistrantException} will be thrown.
-     * </ul>
      */
     public void startBackgroundIsolate(Context context, long callbackHandle) {
         if (backgroundFlutterEngine != null) {
@@ -179,14 +106,12 @@ public class FlutterBackgroundExecutor implements MethodCallHandler {
 
         Log.i(TAG, "Starting BootHandlerService...");
         if (!isRunning()) {
+            this.storedContext = context; // Store context here too
             backgroundFlutterEngine = new FlutterEngine(context);
 
             String appBundlePath = FlutterInjector.instance().flutterLoader().findAppBundlePath();
             AssetManager assets = context.getAssets();
 
-            // We need to create an instance of `FlutterEngine` before looking up the
-            // callback. If we don't, the callback cache won't be initialized and the
-            // lookup will fail.
             FlutterCallbackInformation flutterCallback = FlutterCallbackInformation
                     .lookupCallbackInformation(callbackHandle);
             if (flutterCallback == null) {
@@ -200,11 +125,7 @@ public class FlutterBackgroundExecutor implements MethodCallHandler {
 
             executor.executeDartCallback(dartCallback);
 
-            // The pluginRegistrantCallback should only be set in the V1 embedding as
-            // plugin registration is done via reflection in the V2 embedding.
-            if (pluginRegistrantCallback != null) {
-                pluginRegistrantCallback.registerWith(new ShimPluginRegistry(backgroundFlutterEngine));
-            }
+            Log.i(TAG, "Background isolate started successfully");
         } else {
             Log.e(TAG, "Background isolate already started");
         }
@@ -212,30 +133,19 @@ public class FlutterBackgroundExecutor implements MethodCallHandler {
 
     /**
      * Executes the desired Dart callback in a background Dart isolate.
-     *
-     * <p>
-     * The given {@code intent} should contain a {@code long} extra called
-     * "callbackHandle", which
-     * corresponds to a callback registered with the Dart VM.
      */
-    public void executeDartCallbackInBackgroundIsolate(Context context, Intent intent, final CountDownLatch latch) {
-        // Grab the handle for the dart callback. Pay close
-        // attention to the type of the callback handle as storing this value in a
-        // variable of the wrong size will cause the callback lookup to fail.
-        SharedPreferences preferences = context.getSharedPreferences(BootHandlerService.SHARED_PREFERENCES_KEY,
-                0);
+    public void executeDartCallbackInBackgroundIsolate(Intent intent, final CountDownLatch latch) {
+        if (storedContext == null) {
+            Log.e(TAG, "Context is null, cannot execute Dart callback");
+            if (latch != null) {
+                latch.countDown();
+            }
+            return;
+        }
+
+        SharedPreferences preferences = storedContext.getSharedPreferences(BootHandlerService.SHARED_PREFERENCES_KEY, 0);
         long callbackHandle = preferences.getLong(FlutterBackgroundExecutor.CALLBACK_HANDLE_KEY, 0);
-        // JSONObject params = null;
-        // if (!TextUtils.isEmpty(paramsJsonString)) {
-        // try {
-        // params = new JSONObject(paramsJsonString);
-        // } catch (JSONException e) {
-        // throw new IllegalArgumentException("Can not convert 'params' to JsonObject",
-        // e);
-        // }
-        // }
-        // If another thread is waiting, then wake that thread when the callback returns
-        // a result.
+
         MethodChannel.Result result = null;
         if (latch != null) {
             result = new MethodChannel.Result() {
@@ -258,24 +168,17 @@ public class FlutterBackgroundExecutor implements MethodCallHandler {
 
         Log.i(TAG, "Executing Dart callback: " + callbackHandle + "...");
 
-        // Handle the boot event in Dart. Note that for this plugin, we don't
-        // care about the method name as we simply lookup and invoke the callback
-        // provided.
-        backgroundChannel.invokeMethod(
-                "",
-                new Object[] { callbackHandle },
-                result);
+        if (backgroundChannel != null) {
+            backgroundChannel.invokeMethod("", new Object[] { callbackHandle }, result);
+        } else {
+            Log.e(TAG, "Background channel is null");
+            if (latch != null) {
+                latch.countDown();
+            }
+        }
     }
 
     private void initializeMethodChannel(BinaryMessenger isolate) {
-        // backgroundChannel is the channel responsible for receiving the following
-        // messages from
-        // the background isolate that was setup by this plugin:
-        // - "BootHandlerService.initialized"
-        //
-        // This channel is also responsible for sending requests from Android to Dart to
-        // execute Dart
-        // callbacks in the background isolate.
         backgroundChannel = new MethodChannel(
                 isolate,
                 "com.flux.flutter_boot_receiver/background",

--- a/android/src/main/java/com/flux/flutter_boot_receiver/FlutterBootReceiverPlugin.java
+++ b/android/src/main/java/com/flux/flutter_boot_receiver/FlutterBootReceiverPlugin.java
@@ -9,10 +9,8 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.view.FlutterNativeView;
 import org.json.JSONArray;
 import org.json.JSONException;
-import org.json.JSONObject;
 
 /**
  * Flutter plugin for running one-shot and periodic tasks sometime in the future
@@ -29,7 +27,7 @@ import org.json.JSONObject;
  * invoked by a
  * background Dart isolate.
  * <li>The Android side of this plugin spins up a background
- * {@link FlutterNativeView}, which
+ * {@link io.flutter.embedding.engine.FlutterEngine}, which
  * includes a background Dart isolate.
  * <li>The Android side of this plugin instructs the new background Dart isolate
  * to execute the
@@ -68,9 +66,9 @@ public class FlutterBootReceiverPlugin implements FlutterPlugin, MethodCallHandl
       this.context = applicationContext;
 
       FlutterBootReceiverPluginChannel = new MethodChannel(
-          messenger,
-          "com.flux.flutter_boot_receiver/main",
-          JSONMethodCodec.INSTANCE);
+              messenger,
+              "com.flux.flutter_boot_receiver/main",
+              JSONMethodCodec.INSTANCE);
 
       // Instantiate a new FlutterBootReceiverPlugin and connect the primary
       // method channel for
@@ -83,8 +81,10 @@ public class FlutterBootReceiverPlugin implements FlutterPlugin, MethodCallHandl
   public void onDetachedFromEngine(FlutterPluginBinding binding) {
     Log.i(TAG, "onDetachedFromEngine");
     context = null;
-    FlutterBootReceiverPluginChannel.setMethodCallHandler(null);
-    FlutterBootReceiverPluginChannel = null;
+    if (FlutterBootReceiverPluginChannel != null) {
+      FlutterBootReceiverPluginChannel.setMethodCallHandler(null);
+      FlutterBootReceiverPluginChannel = null;
+    }
   }
 
   public FlutterBootReceiverPlugin() {
@@ -121,115 +121,8 @@ public class FlutterBootReceiverPlugin implements FlutterPlugin, MethodCallHandl
       }
     } catch (JSONException e) {
       result.error("error", "JSON error: " + e.getMessage(), null);
-    } catch (PluginRegistrantException e) {
+    } catch (Exception e) {
       result.error("error", "FlutterBootReceiver error: " + e.getMessage(), null);
     }
   }
 }
-
-// import android.content.Context;
-// import android.content.Intent;
-// import androidx.annotation.NonNull;
-// import io.flutter.embedding.engine.plugins.FlutterPlugin;
-// import io.flutter.plugin.common.MethodCall;
-// import io.flutter.plugin.common.MethodChannel;
-// import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
-// import io.flutter.plugin.common.MethodChannel.Result;
-// import io.flutter.plugin.common.PluginRegistry.Registrar;
-// import java.util.ArrayList;
-// import io.flutter.view.FlutterCallbackInformation;
-// import io.flutter.view.FlutterMain;
-// import io.flutter.view.FlutterNativeView;
-// import io.flutter.view.FlutterRunArguments;
-
-// public class FlutterBootReceiver implements FlutterPlugin, MethodCallHandler
-// {
-
-// public static final String CALLBACK_HANDLE_KEY = "callback_handle_key";
-// public static final String CALLBACK_DISPATCHER_HANDLE_KEY =
-// "callback_dispatcher_handle_key";
-
-// private MethodChannel channel;
-// private static Context mContext;
-
-// @Override
-// public void onAttachedToEngine(@NonNull FlutterPluginBinding
-// flutterPluginBinding) {
-// channel = new MethodChannel(flutterPluginBinding.getBinaryMessenger(),
-// "flutter_boot_receiver/main");
-// channel.setMethodCallHandler(this);
-// mContext = flutterPluginBinding.getApplicationContext();
-// }
-
-// private static long mCallbackDispatcherHandle;
-// private static long mCallbackHandle;
-// private static FlutterRunArguments mFlutterRunArguments;
-// private static FlutterNativeView mBackgroundFlutterView;
-
-// public static long getCallbackDispatcherHandle() {
-// return mCallbackDispatcherHandle;
-// }
-
-// public static long getCallbackHandle() {
-// return mCallbackHandle;
-// }
-
-// public static Context getContext() {
-// return mContext;
-// }
-
-// public static FlutterRunArguments getFlutterRunArguments() {
-// return mFlutterRunArguments;
-// }
-
-// public static FlutterNativeView getBackgroundFlutterView() {
-// return mBackgroundFlutterView;
-// }
-
-// @Override
-// public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {
-
-// if (call.method.equals("initialize")) {
-
-// ArrayList args = call.arguments();
-// long callBackDispatcherHandle = (long) args.get(0);
-// mCallbackDispatcherHandle = callBackDispatcherHandle;
-
-// long callBackHandle = (long) args.get(1);
-// mCallbackHandle = callBackHandle;
-
-// FlutterCallbackInformation flutterCallbackInformation =
-// FlutterCallbackInformation.lookupCallbackInformation(
-// FlutterBootReceiver.getCallbackDispatcherHandle());
-
-// mFlutterRunArguments = new FlutterRunArguments();
-// mFlutterRunArguments.bundlePath = FlutterMain.findAppBundlePath();
-// mFlutterRunArguments.entrypoint = flutterCallbackInformation.callbackName;
-// mFlutterRunArguments.libraryPath =
-// flutterCallbackInformation.callbackLibraryPath;
-
-// mBackgroundFlutterView = new FlutterNativeView(mContext, true);
-
-// result.success(null);
-// return;
-// }
-// // else if (call.method.equals("run")) {
-// // Intent intent = new Intent(mContext, MyService.class);
-// // intent.putExtra(CALLBACK_HANDLE_KEY, mCallbackHandle);
-// // intent.putExtra(CALLBACK_DISPATCHER_HANDLE_KEY,
-// // mCallbackDispatcherHandle);
-// // mContext.startService(intent);
-
-// // result.success(null);
-// // return;
-// // }
-// result.notImplemented();
-// }
-
-// @Override
-// public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
-// channel.setMethodCallHandler(null);
-// }
-// }
-
-// // boot receiver


### PR DESCRIPTION
BREAKING CHANGE: Requires Flutter 3.35.1+ and AGP 8+ This removes support for deprecated V1 embedding API
- Removed Deprecated APIs
- Adjusted some implementations